### PR TITLE
Add View full log URL for easy log viewing

### DIFF
--- a/cemubot/cemubot.py
+++ b/cemubot/cemubot.py
@@ -54,7 +54,7 @@ f"""
 					or not config.cfg["parsing_channel"]["preferred"]:
 						reply_msg = await message.channel.send("Log detected, parsing...")
 						try:
-							await parse_log(log_data, message.channel, reply_msg, self.title_ids)
+							await parse_log(attachment.url, log_data, message.channel, reply_msg, self.title_ids)
 						except Exception as e:
 							await reply_msg.edit(content=f"Error: Couldn't parse log; parser threw {type(e).__name__} exception")
 							traceback.print_exc()

--- a/cemubot/cogs/parser.py
+++ b/cemubot/cogs/parser.py
@@ -178,9 +178,10 @@ class Parser():
 		
 	def create_embed(self):
 		game_title = self.title_ids[self.embed["game_info"]["title_id"]]["game_title"]
-		description = f"[View full log](https://docs.google.com/a/cdn.discordapp.com/viewer?url={self.log_url})"
 		if self.embed["game_info"]["compatibility"]["rating"] != "Unknown":
-			description += f"\n\nTested as **{self.embed['game_info']['compatibility']['rating']}** on {self.embed['game_info']['compatibility']['version']}"
+			description = f"Tested as **{self.embed['game_info']['compatibility']['rating']}** on {self.embed['game_info']['compatibility']['version']}"
+		else:
+			description = "No known compatibility rating yet"
 		# i saw a couple of tests where the rating wasn't one of the standard five,
 		# so i'm putting this in a try-except block just in case
 		try:
@@ -197,7 +198,8 @@ class Parser():
 		game_emu_info = '\n'.join((
 f"**Cemu:** {self.embed['emu_info']['cemu_version']}",
 f"**Cemuhook:** {self.embed['emu_info']['cemuhook_version']}",
-f"**Title version:** v{self.embed['game_info']['title_version']}"
+f"**Title version:** v{self.embed['game_info']['title_version']}",
+f"[View full log](https://google.com)"
 ))
 		specs = '\n'.join((
 f"**CPU:** {self.embed['specs']['cpu']}",

--- a/cemubot/cogs/parser.py
+++ b/cemubot/cogs/parser.py
@@ -199,7 +199,7 @@ class Parser():
 f"**Cemu:** {self.embed['emu_info']['cemu_version']}",
 f"**Cemuhook:** {self.embed['emu_info']['cemuhook_version']}",
 f"**Title version:** v{self.embed['game_info']['title_version']}",
-f"[View full log](https://google.com)"
+f"[View full log](https://docs.google.com/a/cdn.discordapp.com/viewer?url={self.log_url})"
 ))
 		specs = '\n'.join((
 f"**CPU:** {self.embed['specs']['cpu']}",

--- a/cemubot/cogs/parser.py
+++ b/cemubot/cogs/parser.py
@@ -12,10 +12,11 @@ from cogs import config
 class Parser():
 	def __init__(self):
 		self.file = None
+		self.log_url = None
 		self.channel = None
 		self.embed = None
 
-	async def parse_log(self, file, channel, reply_msg, title_ids):
+	async def parse_log(self, log_url, file, channel, reply_msg, title_ids):
 		try:
 			self.file = file.decode('utf-8').replace('\r', '')
 		except UnicodeDecodeError:
@@ -24,6 +25,7 @@ class Parser():
 		self.channel = channel
 		self.reply_msg = reply_msg
 		self.title_ids = title_ids
+		self.log_url = log_url
 		self.embed = {
 			"emu_info": {
 				"cemu_version": "Unknown",
@@ -66,7 +68,13 @@ class Parser():
 			"relevant_info": []
 		}
 		if not re.search(r"------- Loaded title -------", self.file, re.M):
-			await self.reply_msg.edit(content="Error: No game detected. Submit a log during or after emulating a game. Reopening Cemu clears the log.")
+			if re.search(r"Stack trace", self.file, re.M):
+				if re.search(r"\+0x001d9be4", self.file, re.M): # Check for known giveaway caused by acquiring a game copy via a specific tool.
+					await self.reply_msg.edit(content="Error: Cemu crashed before loading the game. This was caused by bad game files.")
+				else:
+					await self.reply_msg.edit(content="Error: Cemu crashed before loading the game. Try making sure that you're using the latest GPU drivers.")
+			else:
+				await self.reply_msg.edit(content="Error: No game detected. Submit a log during or after emulating a game. Reopening Cemu clears the log.")
 			return
 		
 		self.detect_emu_info()
@@ -170,10 +178,9 @@ class Parser():
 		
 	def create_embed(self):
 		game_title = self.title_ids[self.embed["game_info"]["title_id"]]["game_title"]
+		description = f"[View full log](https://docs.google.com/a/cdn.discordapp.com/viewer?url={self.log_url})"
 		if self.embed["game_info"]["compatibility"]["rating"] != "Unknown":
-			description = f"Tested as **{self.embed['game_info']['compatibility']['rating']}** on {self.embed['game_info']['compatibility']['version']}"
-		else:
-			description = "Unknown compatibility rating"
+			description += f"\n\nTested as **{self.embed['game_info']['compatibility']['rating']}** on {self.embed['game_info']['compatibility']['version']}"
 		# i saw a couple of tests where the rating wasn't one of the standard five,
 		# so i'm putting this in a try-except block just in case
 		try:
@@ -181,15 +188,15 @@ class Parser():
 		except KeyError:
 			colour = config.cfg["compatibility_colors"]["unknown"]
 			
-		embed = discord.Embed(colour=discord.Colour(colour), 
+		embed = discord.Embed(colour=discord.Colour(colour),
 							  title=self.embed["game_info"]["title_id"]+(" ("+game_title+")" if game_title else " (Unknown title)"),
-							  url=(self.embed["game_info"]["wiki_page"] or None),
+							  url=(self.embed["game_info"]["wiki_page"] or self.log_url),
 							  description=description,
 							  timestamp=datetime.datetime.utcfromtimestamp(time.time()))
 		# todo: omit unknown info?
 		game_emu_info = '\n'.join((
-f"Cemu {self.embed['emu_info']['cemu_version']}",
-f"Cemuhook {self.embed['emu_info']['cemuhook_version']}",
+f"**Cemu:** {self.embed['emu_info']['cemu_version']}",
+f"**Cemuhook:** {self.embed['emu_info']['cemuhook_version']}",
 f"**Title version:** v{self.embed['game_info']['title_version']}"
 ))
 		specs = '\n'.join((

--- a/cemubot/misc/rulesets.json
+++ b/cemubot/misc/rulesets.json
@@ -10,7 +10,7 @@
             {
                 "property": "emu_info.cemu_version",
                 "type": "ver_lt",
-                "value": "1.18.1"
+                "value": "1.18.0"
             },
             "❓ Cemuhook is not installed"
         ],

--- a/cemubot/misc/rulesets.json
+++ b/cemubot/misc/rulesets.json
@@ -1,11 +1,16 @@
 {
     "any": [
         [
-            "any",
+            "all",
             {
                 "property": "emu_info.cemuhook_version",
                 "type": "str_eq",
                 "value": "N/A"
+            },
+            {
+                "property": "emu_info.cemu_version",
+                "type": "ver_lt",
+                "value": "1.18.1"
             },
             "❓ Cemuhook is not installed"
         ],


### PR DESCRIPTION
Adds a "View Full Log" button to the embed, which uses Google Drive's viewer to show the log that was send.
![Showcase Image](https://cdn.discordapp.com/attachments/645746769795219456/699364761380323368/unknown.png)

Also made the Cemuhook missing error only show up on older Cemu versions since it's functionality is now integrated and added messages when Cemu fails to boot up a game.