### PR TITLE
Fix quote permissions and allow quotes to be made addressable

### DIFF
--- a/cemubot/cemubot.py
+++ b/cemubot/cemubot.py
@@ -81,15 +81,15 @@ f"""
 						traceback.print_exc()
 				else:
 					await message.channel.send(f"Log detected, please post logs in <#{config.cfg['parsing_channel']['preferred']}>.")
-			
+
 		await self.process_commands(message)
 
-intents = discord.Intents.none()
-intents.guilds = True
-intents.messages = True
-intents.dm_messages = True
-
 if __name__ == '__main__':
+	intents = discord.Intents.none()
+	intents.guilds = True
+	intents.messages = True
+	intents.dm_messages = True
+
 	bot = Cemubot(command_prefix=config.cfg["command_prefix"], intents=intents)
 	config.set_bot_instance(bot)
 	bot.slash = SlashCommand(client=bot, sync_commands=True, sync_on_cog_reload=True, override_type=True)

--- a/cemubot/cemubot.py
+++ b/cemubot/cemubot.py
@@ -91,7 +91,6 @@ if __name__ == '__main__':
 	intents.dm_messages = True
 
 	bot = Cemubot(command_prefix=config.cfg["command_prefix"], intents=intents)
-	config.set_bot_instance(bot)
 	bot.slash = SlashCommand(client=bot, sync_commands=True, sync_on_cog_reload=True, override_type=True)
 	bot.load_cogs()
 	bot.run(config.cfg["bot_token"])

--- a/cemubot/cogs/config.py
+++ b/cemubot/cogs/config.py
@@ -8,7 +8,3 @@ def init():
 	global cfg
 	with open("misc/config.cfg", "r", encoding="utf-8") as f:
 		cfg = json.load(f)
-
-def set_bot_instance(bot_instance):
-	global bot
-	bot = bot_instance

--- a/cemubot/cogs/quotes.py
+++ b/cemubot/cogs/quotes.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands, tasks
+from discord.mentions import AllowedMentions
 from discord_slash import cog_ext, SlashContext
 from discord_slash.client import SlashCommand
 from discord_slash.utils.manage_commands import get_all_commands, remove_slash_command, create_permission, create_option, create_choice
@@ -17,19 +18,26 @@ class Quote:
     content = ""
     guild = 0
     response_type = "embed"
+    addressable = False
     slash_command = None
 
-    def __init__(self, slash : SlashCommand, command : str, base_command : str, guild : int, title : str, content : str, response_type : str):
+    def __init__(self, slash : SlashCommand, command : str, base_command : str, guild : int, title : str, content : str, response_type : str, addressable : bool):
         self.command = command
         self.base_command = base_command
         self.guild = guild
         self.title = title
         self.content = content
         self.response_type = response_type
+        self.addressable = addressable
+
+        command_options = None
+        if addressable:
+            command_options = [create_option("user", "User that you want the quote to address", 6, False)]
+        
         if base_command:
-            self.slash_command = slash.add_subcommand(cmd=self.respond, base=base_command, name=self.command, guild_ids=[self.guild], base_default_permission=True)
+            self.slash_command = slash.add_subcommand(cmd=self.respond, base=base_command, name=self.command, guild_ids=[self.guild], base_default_permission=True, options=command_options)
         else:
-            self.slash_command = slash.add_slash_command(cmd=self.respond, name=self.command, guild_ids=[self.guild], default_permission=True)
+            self.slash_command = slash.add_slash_command(cmd=self.respond, name=self.command, guild_ids=[self.guild], default_permission=True, options=command_options)
 
     def to_embed(self):
         if self.title:
@@ -43,14 +51,14 @@ class Quote:
         else:
             return self.content
     
-    async def respond(self, ctx: SlashContext):
+    async def respond(self, ctx: SlashContext, user : discord.Member = None):
         if self.response_type == "embed":
-            await ctx.send(embed=self.to_embed())
+            await ctx.send(embed=self.to_embed(), content=(user.mention if user else None), allowed_mentions=AllowedMentions(users=True))
         elif self.response_type == "text":
-            await ctx.send(content=self.to_message())
+            await ctx.send(content=(user.mention if user else "")+self.to_message(), allowed_mentions=AllowedMentions(users=True))
     
     def save(self):
-        return {"command": self.command, "base": self.base_command, "guild": self.guild, "title": self.title, "content": self.content, "response_type": self.response_type}
+        return {"command": self.command, "base": self.base_command, "guild": self.guild, "title": self.title, "content": self.content, "response_type": self.response_type, "addressable": self.addressable}
 
     async def remove(self, bot, slash : SlashContext):
         self.slash_command
@@ -61,26 +69,47 @@ class Quote:
             if command["name"] == self.command:
                 await remove_slash_command(bot.user.id, config.cfg["bot_token"], slash.guild.id, command["id"])
 
-def generate_guild_ids():
-    return [x.id for x in config.bot.guilds]
-
-def generate_permissions():
-    permissions_per_guild = {}
-    for guild in config.bot.guilds:
-        for guild_role in guild.roles:
-            if guild_role.permissions.manage_roles:
-                permissions_per_guild[guild.id] = create_permission(guild_role.id, 1, True)
-
 class Quotes(commands.Cog):
     quotes : Dict[str, Quote] = {}
+    bot : discord.Client = None
 
     def __init__(self, bot):
         self.bot = bot
 
     @commands.Cog.listener()
     async def on_ready(self):
+        # Load previous commands
         if os.path.isfile("misc/quotes.json"):
             self.load_quotes_from_file()
+
+        # Make list of roles for each guild that should be able to manage quotes
+        guild_ids = []
+        permissions_per_guild = {}
+        async for guild in config.bot.fetch_guilds():
+            guild_ids.append(guild.id)
+            permissions_per_guild[guild.id] = []
+            for guild_role in await guild.fetch_roles():
+                if guild_role.permissions.manage_roles == True:
+                    permissions_per_guild[guild.id].append(create_permission(guild_role.id, 1, True))
+
+        # Add manage commands
+        self.slash_command = self.bot.slash.add_subcommand(base="quote", base_description="Manages the quotes on this server", guild_ids=guild_ids, base_default_permission=False, base_permissions=permissions_per_guild,
+            cmd=self.quote_add, name="add", description="Adds a new quote command.", options=[
+                create_option(name="name", description="Name of the new command that you want to add. Can't include any spaces!", option_type=3, required=True),
+                create_option(name="title", description="Title of the quote. Use \"None\" if you want to have no title.", option_type=3, required=True),
+                create_option(name="description", description="Description of the quote. Supports markdown and $user to make an addressed quote!", option_type=3, required=True),
+                create_option(name="type", description="Type of the response", option_type=3, required=True, choices=[create_choice(name="Embed Response", value="embed"), create_choice(name="Text Response", value="text")]),
+                create_option(name="parent", description="Name of the parent command where this command name will be nested under.", option_type=3, required=False),
+                create_option(name="addressable", description="Should the command have an optional user specifier which when used will mention the given user.", option_type=5, required=False)
+            ])
+        
+        self.slash_command = self.bot.slash.add_subcommand(
+            base="quote", base_description="Manages the quotes on this server", guild_ids=guild_ids, base_default_permission=False, base_permissions=permissions_per_guild,
+            cmd=self.quote_delete, name="delete", options=[
+                create_option(name="command", description="Command that's associated with the quote. Don't include the name of the parent command.", option_type=3, required=True)
+            ])
+        
+        # Sync all the loaded quotes and management commands
         await self.bot.slash.sync_all_commands()
     
     def load_quotes_from_file(self):
@@ -88,7 +117,7 @@ class Quotes(commands.Cog):
         with open("misc/quotes.json", "r", encoding="utf-8") as f:
             quotesJson = json.load(f)
             for quoteJson in quotesJson:
-                self.quotes[quoteJson["command"]] = Quote(self.bot.slash, quoteJson["command"], quoteJson["base"], quoteJson["guild"], quoteJson["title"], quoteJson["content"], quoteJson["response_type"])
+                self.quotes[quoteJson["command"]] = Quote(self.bot.slash, quoteJson["command"], quoteJson["base"], quoteJson["guild"], quoteJson["title"], quoteJson["content"], quoteJson["response_type"], quoteJson["addressable"])
     
     def save_quotes_to_file(self):
         with open("misc/quotes.json", "w") as f:
@@ -96,39 +125,18 @@ class Quotes(commands.Cog):
             for quote in self.quotes.values():
                 storeCommands.append(quote.save())
             json.dump(storeCommands, f, indent="\t")
-    
-    @cog_ext.cog_subcommand(guild_ids=generate_guild_ids(), base="quote", base_desc="Manages the quotes on this server.", base_default_permission=False, base_permissions=generate_permissions(),
-    name="list", description="Lists all the existing quotes.")
-    async def quote_list(self, ctx: SlashContext):
-        listResponse = "Listing all commands:\n"
-        for quote in self.quotes.values():
-            listResponse += f" - {quote.command}"
-            if quote.base_command:
-                listResponse += f" (parent {quote.base_command})"
-            listResponse += "\n"
-        await ctx.send(content=listResponse)
 
-    @cog_ext.cog_subcommand(guild_ids=generate_guild_ids(), base="quote", base_desc="Manages the quotes on this server.", base_default_permission=False, base_permissions=generate_permissions(),
-    name="add", description="Adds a new quote command.", options=[
-        create_option(name="name", description="Name of the new command that you want to add. Can't include any spaces!", option_type=3, required=True),
-        create_option(name="title", description="Title of the quote. Use \"None\" if you want to have no title.", option_type=3, required=True),
-        create_option(name="description", description="Description of the quote. Supports markdown!", option_type=3, required=True),
-        create_option(name="type", description="Type of the response", option_type=3, required=True, choices=[create_choice(name="Embed Response", value="embed"), create_choice(name="Text Response", value="text")]),
-        create_option(name="parent", description="Name of the parent command where this command name will be nested under.", option_type=3, required=False)
-    ])
-    async def quote_add(self, ctx: SlashContext, name : str, title: str, description : str, type : str, parent : str = ""):
+    async def quote_add(self, ctx: SlashContext, name : str, title: str, description : str, type : str, parent : str = "", addressable : bool = False):
         if " " in name:
             await ctx.send("You can't use spaces in the command names!")
             return
         if title.lower() == "none":
             title = ""
-        self.quotes[name] = Quote(self.bot.slash, name.lower(), parent, ctx.guild.id, title, description, type)
+        self.quotes[name] = Quote(self.bot.slash, name.lower(), parent, ctx.guild.id, title, description, type, addressable)
         await self.quotes[name].respond(ctx)
         self.save_quotes_to_file()
         await self.bot.slash.sync_all_commands()
 
-    @cog_ext.cog_subcommand(guild_ids=generate_guild_ids(), base="quote", base_desc="Manages the quotes on this server.", base_default_permission=False, base_permissions=generate_permissions(),
-    name="delete", description="Deletes the given quote command.", options=[create_option(name="command", description="Command that's associated with the quote.", option_type=3, required=True)])
     async def quote_delete(self, ctx: SlashContext, command : str):
         await self.quotes[command].remove(self.bot, ctx)
         del self.quotes[command]

--- a/cemubot/cogs/quotes.py
+++ b/cemubot/cogs/quotes.py
@@ -85,7 +85,7 @@ class Quotes(commands.Cog):
         # Make list of roles for each guild that should be able to manage quotes
         guild_ids = []
         permissions_per_guild = {}
-        async for guild in config.bot.fetch_guilds():
+        async for guild in self.bot.fetch_guilds():
             guild_ids.append(guild.id)
             permissions_per_guild[guild.id] = []
             for guild_role in await guild.fetch_roles():

--- a/cemubot/cogs/site.py
+++ b/cemubot/cogs/site.py
@@ -10,6 +10,7 @@ import aiohttp
 from cogs import config
 
 class Site(commands.Cog):
+    bot : discord.Client = None
     version_list = []
     public_release_date = datetime.utcfromtimestamp(0)
     patreon_release = None
@@ -22,7 +23,7 @@ class Site(commands.Cog):
         self.updatePatreonStatus.start()
 
     @cog_ext.cog_slash(name="download", description="Gives a link to download a specific (older) version of Cemu.", options=[
-        create_option(name="version", description="Type the Cemu version you want a download link of", option_type=3, required=False)
+        create_option(name="version", description="Type the Cemu version you want a download link", option_type=3, required=True)
     ])
     async def downloadLink(self, ctx: SlashContext, version: str):
         if version.lower() == "latest":
@@ -42,7 +43,7 @@ class Site(commands.Cog):
                 if len(corrected_versions) > 1:
                     await ctx.send(content=f"That version never existed, but did you mean Cemu {corrected_versions[0]}? The download link is <http://cemu.info/releases/cemu_{corrected_versions[0]}.zip>")
                 else:
-                    await ctx.send(content="Are you from the future, or does this version just not exist yet!")
+                    await ctx.send(content="Are you from the future, or does this version just not exist yet?!")
 
     async def update_activity(self):
         if len(self.version_list) == 0:


### PR DESCRIPTION
 - Fix a bug where none of the quote management commands could be used. Caused by the bot not having started up yet when the class is initialized and expects the guilds to be already known.
 - Can now create a new type of quote where you can allow users to mention or "address" a specific user.
 - Also fixed a mistake where the /download version command was optional.
 - Remove the global instance that was used to workaround some limitations.