### PR TITLE
Fix permission syncing

### DIFF
--- a/cemubot/cemubot.py
+++ b/cemubot/cemubot.py
@@ -41,6 +41,11 @@ f"""
 				exc = f"{type(e).__name__}: {e}"
 				print(f"Failed to load extension {extension}\n{exc}")
 				traceback.print_exc()
+	quotes_ready = False
+	rules_ready = False
+	async def sync_commands_when_finished(self):
+		if self.quotes_ready and self.rules_ready:
+			await self.slash.sync_all_commands()
 	async def on_message(self, message):
 		if message.author.id == self.user.id:
 			return
@@ -92,6 +97,6 @@ if __name__ == '__main__':
 	intents.dm_messages = True
 
 	bot = Cemubot(command_prefix=config.cfg["command_prefix"], intents=intents)
-	bot.slash = SlashCommand(client=bot, sync_commands=True, sync_on_cog_reload=True, override_type=True)
+	bot.slash = SlashCommand(client=bot)
 	bot.load_cogs()
 	bot.run(config.cfg["bot_token"])

--- a/cemubot/cogs/quotes.py
+++ b/cemubot/cogs/quotes.py
@@ -137,6 +137,7 @@ class Quotes(commands.Cog):
             return
         if title.lower() == "none":
             title = ""
+        await ctx.defer()
         self.quotes[name] = Quote(self.bot.slash, name.lower(), parent, ctx.guild.id, title, description, type, addressable)
         self.save_quotes_to_file()
         await self.bot.slash.sync_all_commands()
@@ -184,6 +185,7 @@ class Quotes(commands.Cog):
             return
         
         # Delete (parent) command
+        await ctx.defer()
         if matched_parent and not matched_command:
             # Delete single command
             await self.quotes[parent_children[0]].remove(self.bot, ctx)
@@ -192,7 +194,6 @@ class Quotes(commands.Cog):
         else:
             await self.quotes[command].remove(self.bot, ctx)
             del self.quotes[command]
-            del self.bot.slash.commands[command]
         await ctx.send(content="Successfully deleted the command!")
         self.save_quotes_to_file()
         await self.bot.slash.sync_all_commands()

--- a/cemubot/cogs/quotes.py
+++ b/cemubot/cogs/quotes.py
@@ -89,23 +89,7 @@ class Quotes(commands.Cog):
         if os.path.isfile("misc/quotes.json"):
             self.load_quotes_from_file()
 
-        # Add the manage commands
-        self.bot.slash.add_subcommand(base="quote", base_description="Manages the quotes on this server", base_default_permission=False,
-            cmd=self.quote_add, name="add", description="Adds a new quote command.", options=[
-                create_option(name="name", description="Name of the new command that you want to add. Can't include any spaces!", option_type=3, required=True),
-                create_option(name="title", description="Title of the quote. Use \"None\" if you want to have no title.", option_type=3, required=True),
-                create_option(name="description", description="Description of the quote. Supports markdown!", option_type=3, required=True),
-                create_option(name="type", description="Type of the response", option_type=3, required=True, choices=[create_choice(name="Embed Response", value="embed"), create_choice(name="Text Response", value="text")]),
-                create_option(name="parent", description="Name of the parent command where this command name will be nested under.", option_type=3, required=False),
-                create_option(name="addressable", description="Should the command have an optional user specifier which when used will mention the given user.", option_type=5, required=False)
-            ])
-        
-        self.bot.slash.add_subcommand(
-            base="quote", base_description="Manages the quotes on this server", base_default_permission=False,
-            cmd=self.quote_delete, name="delete", description="Deletes an existing quote command.", options=[
-                create_option(name="command", description="Deletes a parent command.", option_type=3, required=True)
-            ])
-
+        # Set the manage commands permissions and sync if it's fully done
         await self.set_quote_permissions()
         self.bot.quotes_ready = True
         await self.bot.sync_commands_when_finished()
@@ -137,7 +121,16 @@ class Quotes(commands.Cog):
             for quote in self.quotes.values():
                 storeCommands.append(quote.save())
             json.dump(storeCommands, f, indent="\t")
-
+    
+    @cog_ext.cog_subcommand(base="quote", base_description="Manages the quotes on this server", base_default_permission=False,
+        name="add", description="Adds a new quote command.", options=[
+            create_option(name="name", description="Name of the new command that you want to add. Can't include any spaces!", option_type=3, required=True),
+            create_option(name="title", description="Title of the quote. Use \"None\" if you want to have no title.", option_type=3, required=True),
+            create_option(name="description", description="Description of the quote. Supports markdown!", option_type=3, required=True),
+            create_option(name="type", description="Type of the response", option_type=3, required=True, choices=[create_choice(name="Embed Response", value="embed"), create_choice(name="Text Response", value="text")]),
+            create_option(name="parent", description="Name of the parent command where this command name will be nested under.", option_type=3, required=False),
+            create_option(name="addressable", description="Should the command have an optional user specifier which when used will mention the given user.", option_type=5, required=False)
+        ])
     async def quote_add(self, ctx: SlashContext, name : str, title: str, description : str, type : str, parent : str = "", addressable : bool = False):
         if " " in name:
             await ctx.send("You can't use spaces in the command names!", hidden=True)
@@ -161,7 +154,11 @@ class Quotes(commands.Cog):
         if type is not None and (type == "embed" or type == "text"):
             self.quotes[name].type = type
         self.save_quotes_to_file()
-
+    
+    @cog_ext.cog_subcommand(base="quote", base_description="Manages the quotes on this server", base_default_permission=False,
+        name="delete", description="Deletes an existing quote command.", options=[
+            create_option(name="command", description="Deletes a parent command.", option_type=3, required=True)
+        ])
     async def quote_delete(self, ctx: SlashContext, command : str):
         has_parent = False
         matched_command = False

--- a/cemubot/cogs/rules.py
+++ b/cemubot/cogs/rules.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands, tasks
-from discord_slash import SlashContext
+from discord_slash import SlashContext, cog_ext
 from discord_slash.context import ComponentContext
 from discord_slash.model import BaseCommandObject, ButtonStyle
 from discord_slash.utils.manage_components import create_button, create_actionrow
@@ -13,23 +13,13 @@ from cogs import permissions
 
 class Rules(commands.Cog):
     bot : Cemubot = None
-    rules_command : BaseCommandObject = None
 
     def __init__(self, bot):
         self.bot = bot
 
     @commands.Cog.listener()
     async def on_ready(self):
-        # Add the rules command
-        self.rules_command = self.bot.slash.add_slash_command(cmd=self.change_rules, name="rules", description="Sets the rules in the server and lists the new rules greeting.", default_permission=False, options=[
-                create_option(name="rule1", description="Text for rule 1", option_type=3, required=True),
-                create_option(name="rule2", description="Text for rule 2", option_type=3, required=True),
-                create_option(name="rule3", description="Text for rule 3", option_type=3, required=True),
-                create_option(name="rule4", description="Text for rule 4", option_type=3, required=True),
-                create_option(name="rule5", description="Text for rule 5", option_type=3, required=True),
-                create_option(name="rule6", description="Text for rule 6", option_type=3, required=True)
-            ])
-
+        # Change the rules command permissions
         await self.set_rules_permissions()
         self.bot.rules_ready = True
         await self.bot.sync_commands_when_finished()
@@ -46,8 +36,16 @@ class Rules(commands.Cog):
             if guild.id in permissions.user_permissions:
                 for user_id in permissions.user_permissions[guild.id]:
                     rules_permissions[guild.id].append(create_permission(user_id, 2, True))
-        self.rules_command.permissions = rules_permissions
-
+        self.bot.slash.commands["rules"].permissions = rules_permissions
+    
+    @cog_ext.cog_slash(name="rules", description="Sets the rules in the server and lists the new rules greeting.", default_permission=False, options=[
+            create_option(name="rule1", description="Text for rule 1", option_type=3, required=True),
+            create_option(name="rule2", description="Text for rule 2", option_type=3, required=True),
+            create_option(name="rule3", description="Text for rule 3", option_type=3, required=True),
+            create_option(name="rule4", description="Text for rule 4", option_type=3, required=True),
+            create_option(name="rule5", description="Text for rule 5", option_type=3, required=True),
+            create_option(name="rule6", description="Text for rule 6", option_type=3, required=True)
+        ])
     async def change_rules(self, ctx: SlashContext, rule1, rule2, rule3, rule4, rule5, rule6):
         quotes_cog = self.bot.get_cog("Quotes")
         if quotes_cog:
@@ -77,9 +75,6 @@ class Rules(commands.Cog):
                 create_button(style=ButtonStyle.URL, label="Patreon", url="https://www.patreon.com/cemu"),
                 create_button(style=ButtonStyle.URL, label="Setup Guide", url="https://cemu.cfw.guide/"),
                 create_button(style=ButtonStyle.URL, label="Discord Invite Link", url="https://discord.gg/5psYsup")
-            ]),
-            create_actionrow(*[
-                create_button(style=ButtonStyle.secondary, label="How To Get Patreon Role?")
             ])
         ])
 

--- a/cemubot/cogs/rules.py
+++ b/cemubot/cogs/rules.py
@@ -2,11 +2,10 @@ import discord
 from discord.ext import commands, tasks
 from discord_slash import SlashContext
 from discord_slash.context import ComponentContext
-from discord_slash.model import ButtonStyle
+from discord_slash.model import BaseCommandObject, ButtonStyle
 from discord_slash.utils.manage_components import create_button, create_actionrow
 from discord_slash.utils.manage_commands import get_all_commands, create_permission, create_option, update_guild_commands_permissions
 
-import os
 from cemubot import Cemubot
 
 from cogs import config
@@ -14,18 +13,15 @@ from cogs import permissions
 
 class Rules(commands.Cog):
     bot : Cemubot = None
+    rules_command : BaseCommandObject = None
 
     def __init__(self, bot):
         self.bot = bot
 
     @commands.Cog.listener()
     async def on_ready(self):
-        guild_ids = []
-        async for guild in self.bot.fetch_guilds():
-            guild_ids.append(guild.id)
-
         # Add the rules command
-        self.bot.slash.add_slash_command(cmd=self.change_rules, name="rules", description="Sets the rules in the server and lists the new rules greeting.", guild_ids=guild_ids, default_permission=False, options=[
+        self.rules_command = self.bot.slash.add_slash_command(cmd=self.change_rules, name="rules", description="Sets the rules in the server and lists the new rules greeting.", default_permission=False, options=[
                 create_option(name="rule1", description="Text for rule 1", option_type=3, required=True),
                 create_option(name="rule2", description="Text for rule 2", option_type=3, required=True),
                 create_option(name="rule3", description="Text for rule 3", option_type=3, required=True),
@@ -33,31 +29,24 @@ class Rules(commands.Cog):
                 create_option(name="rule5", description="Text for rule 5", option_type=3, required=True),
                 create_option(name="rule6", description="Text for rule 6", option_type=3, required=True)
             ])
-        await self.bot.slash.sync_all_commands()
 
         await self.set_rules_permissions()
+        self.bot.rules_ready = True
+        await self.bot.sync_commands_when_finished()
         permissions.register_update_handler(self.set_rules_permissions)
     
     async def set_rules_permissions(self):
-        # Make and set list of permissions set for each guild, then update the permissions of the roles command
-        async for guild in self.bot.fetch_guilds():
-            guild_permissions = []
+        rules_permissions = {}
+        for guild in self.bot.guilds:
+            rules_permissions[guild.id] = []
 
             if guild.id in permissions.role_permissions:
                 for role_id in permissions.role_permissions[guild.id]:
-                    guild_permissions.append(create_permission(role_id, 1, True))
+                    rules_permissions[guild.id].append(create_permission(role_id, 1, True))
             if guild.id in permissions.user_permissions:
                 for user_id in permissions.user_permissions[guild.id]:
-                    guild_permissions.append(create_permission(user_id, 2, True))
-
-            # Manual requests to update the permissions for the already synced commands
-            command_permissions = []
-            syncedCommands = await get_all_commands(self.bot.user.id, config.cfg["bot_token"], guild.id)
-            for command in syncedCommands:
-                if command["name"] == "rules":
-                    command_permissions.append({"id": command["id"], "permissions": guild_permissions})
-                    break
-            await update_guild_commands_permissions(self.bot.user.id, config.cfg["bot_token"], guild.id, command_permissions)
+                    rules_permissions[guild.id].append(create_permission(user_id, 2, True))
+        self.rules_command.permissions = rules_permissions
 
     async def change_rules(self, ctx: SlashContext, rule1, rule2, rule3, rule4, rule5, rule6):
         quotes_cog = self.bot.get_cog("Quotes")
@@ -85,8 +74,12 @@ class Rules(commands.Cog):
             create_actionrow(*[
                 create_button(style=ButtonStyle.URL, label="Cemu.info Website", url="https://cemu.info/"),
                 create_button(style=ButtonStyle.URL, label="Compatibility Wiki", url="https://wiki.cemu.info/wiki/Main_Page"),
-                create_button(style=ButtonStyle.URL, label="Cemu Setup Guide", url="https://cemu.cfw.guide/"),
+                create_button(style=ButtonStyle.URL, label="Patreon", url="https://www.patreon.com/cemu"),
+                create_button(style=ButtonStyle.URL, label="Setup Guide", url="https://cemu.cfw.guide/"),
                 create_button(style=ButtonStyle.URL, label="Discord Invite Link", url="https://discord.gg/5psYsup")
+            ]),
+            create_actionrow(*[
+                create_button(style=ButtonStyle.secondary, label="How To Get Patreon Role?")
             ])
         ])
 

--- a/cemubot/cogs/rules.py
+++ b/cemubot/cogs/rules.py
@@ -47,6 +47,7 @@ class Rules(commands.Cog):
             create_option(name="rule6", description="Text for rule 6", option_type=3, required=True)
         ])
     async def change_rules(self, ctx: SlashContext, rule1, rule2, rule3, rule4, rule5, rule6):
+        ctx.defer()
         quotes_cog = self.bot.get_cog("Quotes")
         if quotes_cog:
             await quotes_cog.quote_edit(ctx, name="r1", description=rule1)


### PR DESCRIPTION
 - Found a way to inject permissions after defining the command, which fixes issues where the library might try to sync it's internal empty permissions when there's a mismatch.
 - Do a final sync after all the slash commands are all loaded.
 - Use cogs again since apparently you can set permissions of global variables.
 - Change to manually syncing at correct times.