### PR TITLE
Improve version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A custom bot for the [Cemu Discord server.](https://discord.gg/5psYsup)
 - [requests](https://docs.python-requests.org)
 - [discord.py](https://github.com/Rapptz/discord.py) 1.5.0+
 - [discord-py-slash-command](https://github.com/discord-py-slash-commands/discord-py-interactions)
-- [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
+- [thefuzz](https://github.com/seatgeek/thefuzz)
 
 # Installation
 1. Download this repository

--- a/cemubot/cogs/compat.py
+++ b/cemubot/cogs/compat.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from fuzzywuzzy import process
+from thefuzz import process
 import discord
 import urllib.parse
 import re

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ def configure():
         "unplayable": 0xBF3E32,
         "unknown": 0x858585
     }
-    config["announcement_channel"] = int(input("Put the channel ID of the announcement channel here (0 to not keep track of patreon releases): "))
     print(f"Your config file now looks like this:\n{json.dumps(config, indent=2)}")
     if input("Is this correct? (y/n) ").lower() == 'n':
         f.close()


### PR DESCRIPTION
 - Now uses an internal API that Cemu uses for it's auto updater for it's discord status
 - Add exception logging to catch errors to see why it's failing to get the changelog page sometimes
 - Removes the patreon release tracking
 - Also updated the fuzzywuzzy dependency to use the new fork/version.